### PR TITLE
Add Bugzilla api key login support

### DIFF
--- a/bzrest/client.py
+++ b/bzrest/client.py
@@ -15,6 +15,8 @@ class BugzillaClient(object):
             self.apikey = apikey
             self.username = None
             self.password = None
+            if username or password:
+                raise ValueError("Cannot use apikey along with user-based login")
         elif username and password:
             self.apikey = None
             self.username = username


### PR DESCRIPTION
I'm not a big fan of the code flow after this change, but I wanted to get a api key support in sooner than later.

This code allows specifying both user+pass and key, but will always use the key if provided. (It also sets the user+password to None if apikey is used, to try and limit the amount of places in memory the password could be stored, even if passed in)

As of tonight this code is untested. However api key support is defined at http://bugzilla.readthedocs.org/en/latest/api/core/v1/general.html#authentication