### PR TITLE
Fix regression that prevents passing None for user/password as a mean…

### DIFF
--- a/bzrest/client.py
+++ b/bzrest/client.py
@@ -10,17 +10,19 @@ log = logging.getLogger(__name__)
 
 
 class BugzillaClient(object):
-    def configure(self, bzurl, username=None, password=None, apikey=None):
-        if apikey:
-            self.apikey = apikey
+    def configure(self, bzurl, **kwargs):
+        if not set(kwargs.keys()).issubset(set(["password", "username", "apikey"])):
+            raise ValueError("Invalid arguments passed to BugzillaClient.configure")
+        if "apikey" in kwargs:
+            self.apikey = kwargs["apikey"]
             self.username = None
             self.password = None
-            if username or password:
+            if kwargs.get("username", None) or kwargs.get("password", None):
                 raise ValueError("Cannot use apikey along with user-based login")
-        elif username and password:
+        elif "username" in kwargs and "password" in kwargs:
             self.apikey = None
-            self.username = username
-            self.password = password
+            self.username = kwargs["username"]
+            self.password = kwargs["password"]
         else:
             raise ValueError("One of apikey or username & password must be supplied")
 


### PR DESCRIPTION
…s for no-bmo-login

Turns out I regressed the "don't actually use a user/login", this code allows you to specify ```None``` and happily accepts it, while still having sane defaults.

I suppose there is argument to be made that this code is not pythonic/sane since it is essentially two method signatures with the same name, and we might want to make a configureApiKey and configureUser (with configure itself defaulting to user, to match old behavior) but I think this at least satisfies the existing use-cases.

I suggest we release this change as 1.0.1 not 1.1